### PR TITLE
trivy scan before push

### DIFF
--- a/.github/workflows/docker-build-push-scan.yml
+++ b/.github/workflows/docker-build-push-scan.yml
@@ -17,7 +17,7 @@ env:
   git_commit: ${{ github.sha }}
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2

--- a/.github/workflows/docker-build-push-scan.yml
+++ b/.github/workflows/docker-build-push-scan.yml
@@ -39,6 +39,15 @@ jobs:
         tags: |
           ghcr.io/${{ github.repository }}:${{ env.git_commit }}
           ghcr.io/${{ github.repository }}:latest
+    - name: Run Trivy vulnerability scanner
+      uses: aquasecurity/trivy-action@master
+      with:
+        image-ref: ghcr.io/${{ github.repository }}:${{ env.git_commit }}
+        format: 'table'
+        exit-code: '1'
+        ignore-unfixed: true
+        vuln-type: 'os,library'
+        severity: 'CRITICAL'
     - name: Docker push
       uses: docker/build-push-action@v3
       with:
@@ -51,20 +60,3 @@ jobs:
           ghcr.io/${{ github.repository }}:latest
         cache-from: type=gha
         cache-to: type=gha,mode=max
-  scan:
-    runs-on: ubuntu-22.04
-    needs: build
-    steps:
-    - uses: actions/checkout@v3
-    - name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@master
-      with:
-        image-ref: ghcr.io/${{ github.repository }}:${{ env.git_commit }}
-        format: 'table'
-        exit-code: '1'
-        ignore-unfixed: true
-        vuln-type: 'os,library'
-        severity: 'CRITICAL'
-      env:
-        TRIVY_USERNAME: ${{ github.repository_owner }}
-        TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
allows agent without ghcr push permission (e.g. dependabot) to still complete a scan