### PR TITLE
Add secret-check workflow

### DIFF
--- a/.github/workflows/secret-check.yml
+++ b/.github/workflows/secret-check.yml
@@ -44,7 +44,7 @@ jobs:
         # Load the output of a CLI command into an array
         ssmSecrets=${{ steps.ssmSecrets.outputs.ssmSecrets }}
         manifestString="${{ steps.manifestSecrets.outputs.result }}"
-        IFS = '\n-' read -r -a manifestSecrets <<< "$manifestString"
+        IFS='\n-' read -r -a manifestSecrets <<< "$manifestString"
 
         # Iterate over the array and print the values
         REGEX='([A-Za-z0-9_]+)'

--- a/.github/workflows/secret-check.yml
+++ b/.github/workflows/secret-check.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Get secrets from Param Store in SSM
       id: ssmSecrets
       run: |
-        echo "ssmSecrets=$(aws ssm get-parameters-by-path --output json --recursive --path /copilot/${{ vars.COPILOT_APPLICATION }}/${{ vars.COPILOT_ENVIRONMENT }}/secrets | jq '.Parameters[].Name')" >> $GITHUB_OUTPUT
+        echo "ssmSecrets=$(aws ssm get-parameters-by-path --output json --recursive --path /copilot/${{ vars.COPILOT_APPLICATION }}/${{ vars.COPILOT_ENVIRONMENT }}/secrets | jq '.Parameters[].Name') | jq -s -c" >> $GITHUB_OUTPUT
     - name: Compare secrets
       run: |
         #!/bin/bash

--- a/.github/workflows/secret-check.yml
+++ b/.github/workflows/secret-check.yml
@@ -26,7 +26,7 @@ jobs:
       id: manifestSecrets
       uses: mikefarah/yq@master
       with:
-        cmd: yq '.secrets | keys' copilot/${{ vars.COPILOT_SERVICE }}/manifest.yml | yq -c
+        cmd: yq -c '.secrets | keys' copilot/${{ vars.COPILOT_SERVICE }}/manifest.yml
     
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/secret-check.yml
+++ b/.github/workflows/secret-check.yml
@@ -43,9 +43,11 @@ jobs:
 
         # Load the output of a CLI command into an array
         ssmString=${{ steps.ssmSecrets.outputs.ssmSecrets }}
-        manifestString=${{ steps.manifestSecrets.outputs.result }}
+        manifestSecrets=${{ steps.manifestSecrets.outputs.result }}
         IFS=',' read -r -a ssmSecrets <<< "$ssmString"
-        IFS='\n-' read -r -a manifestSecrets <<< "$manifestString"
+        #IFS='\n-' read -r -a manifestSecrets <<< "$manifestString"
+        echo "ssmSecrets=${ssmSecrets[*]}"
+        echo "manSecrets=${manifestSecrets[*]}"
 
         # Iterate over the array and print the values
         REGEX='([A-Za-z0-9_]+)'

--- a/.github/workflows/secret-check.yml
+++ b/.github/workflows/secret-check.yml
@@ -43,7 +43,7 @@ jobs:
 
         # Load the output of a CLI command into an array
         ssmSecrets=${{ steps.ssmSecrets.outputs.ssmSecrets }}
-        manifestSecrets=${{ steps.manifestSecrets.outputs.result }}
+        manifestSecrets=[${{ steps.manifestSecrets.outputs.result }}]
 
         # Iterate over the array and print the values
         REGEX='([A-Za-z0-9_]+)'

--- a/.github/workflows/secret-check.yml
+++ b/.github/workflows/secret-check.yml
@@ -46,8 +46,8 @@ jobs:
         manifestSecrets=${{ steps.manifestSecrets.outputs.result }}
         IFS=',' read -r -a ssmSecrets <<< "$ssmString"
         #IFS='\n-' read -r -a manifestSecrets <<< "$manifestString"
-        echo "ssmSecrets=${ssmSecrets[*]}"
-        echo "manSecrets=${manifestSecrets[*]}"
+        echo "ssmSecrets = ${ssmSecrets[*]}"
+        echo "manSecrets = ${manifestSecrets[*]}"
 
         # Iterate over the array and print the values
         REGEX='([A-Za-z0-9_]+)'

--- a/.github/workflows/secret-check.yml
+++ b/.github/workflows/secret-check.yml
@@ -55,9 +55,9 @@ jobs:
 
         # Load the output of a CLI command into an array
         ssmString=${{ steps.ssmSecrets.outputs.ssmSecrets }}
-        manifestSecrets=${{ steps.manifestSecrets.outputs.result }}
+        manifestString=${{ steps.manifestSecrets.outputs.result }}
         IFS=',' read -r -a ssmSecrets <<< "$ssmString"
-        #IFS='\n-' read -r -a manifestSecrets <<< "$manifestString"
+        IFS=',' read -r -a manifestSecrets <<< "$manifestString"
         echo "ssmSecrets = ${ssmSecrets[*]}"
         echo "manSecrets = ${manifestSecrets[*]}"
 

--- a/.github/workflows/secret-check.yml
+++ b/.github/workflows/secret-check.yml
@@ -1,0 +1,69 @@
+name: Validate that secrets in service manifest exist in a copilot environment
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        description: 'GitHub repo environment name'
+        required: true
+        type: string
+    secrets:
+      AWS_ROLE_TO_ASSUME:
+        description: 'IAM role with copilot permissions'
+        required: true
+
+jobs:
+  secret-check:
+    environment: ${{ inputs.environment }}
+    permissions:
+      id-token: write
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v4
+    - name: Get secrets from manifest.yml
+      id: manifestSecrets
+      uses: mikefarah/yq@master
+      with:
+        cmd: yq '.secrets | keys' copilot/evidence-hub/manifest.yml
+    
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        aws-region: ${{ vars.AWS_REGION }}
+        role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+    - name: Get secrets from Param Store in SSM
+      id: ssmSecrets
+      run: |
+        echo "ssmSecrets=$(aws ssm get-parameters-by-path --recursive --path /copilot/evidence-hub-dashboard/dev/secrets | jq .Parameters[].Name)" >> $GITHUB_OUTPUT
+    
+    - name: Compare secrets
+      run: |
+        #!/bin/bash
+
+        # Load the output of a CLI command into an array
+        ssmSecrets=(${{ steps.ssmSecrets.outputs.ssmSecrets }})
+        manifestSecrets=(${{ steps.manifestSecrets.outputs.result }})
+
+        # Iterate over the array and print the values
+        REGEX='([A-Za-z0-9_]+)'
+        for value in "${manifestSecrets[@]}"
+        do
+            if [ "$value" != "[" ] && [ "$value" != "]" ]; then
+              # extract just regex match from value
+              [[ $value =~ $REGEX ]] && value=${BASH_REMATCH[1]}
+              found=false
+              target="/copilot/evidence-hub-dashboard/dev/secrets/$value"
+              for ((idx=0; idx<${#ssmSecrets[@]}; ++idx)); do
+                if grep -q "$value" <<< "${ssmSecrets[$idx]}"; then
+                  found=true;
+                fi
+              done
+              if [ $found == false ]; then
+                echo "NOT FOUND $value";
+                exit 1;
+              fi
+            fi
+        done
+        exit 0;

--- a/.github/workflows/secret-check.yml
+++ b/.github/workflows/secret-check.yml
@@ -42,8 +42,8 @@ jobs:
         #!/bin/bash
 
         # Load the output of a CLI command into an array
-        ssmSecrets=(${{ steps.ssmSecrets.outputs.ssmSecrets }})
-        manifestSecrets=$(${{ steps.manifestSecrets.outputs.result }} | jq .Parameters[].Name )
+        ssmSecrets=$(${{ steps.ssmSecrets.outputs.ssmSecrets }} | jq '.Parameters[].Name')
+        manifestSecrets=${{ steps.manifestSecrets.outputs.result }}
 
         # Iterate over the array and print the values
         REGEX='([A-Za-z0-9_]+)'

--- a/.github/workflows/secret-check.yml
+++ b/.github/workflows/secret-check.yml
@@ -43,7 +43,7 @@ jobs:
 
         # Load the output of a CLI command into an array
         ssmSecrets=$(${{ steps.ssmSecrets.outputs.ssmSecrets }} | jq '.Parameters[].Name')
-        manifestSecrets=${{ steps.manifestSecrets.outputs.result }}
+        manifestSecrets=(${{ steps.manifestSecrets.outputs.result }})
 
         # Iterate over the array and print the values
         REGEX='([A-Za-z0-9_]+)'

--- a/.github/workflows/secret-check.yml
+++ b/.github/workflows/secret-check.yml
@@ -53,7 +53,7 @@ jobs:
             echo "value1 = $value"
             if [ $value =~ $REGEX ]; then
               # extract just regex match from value
-              [[ $value =~ $REGEX ]] && value=${BASH_REMATCH[1]}
+              #[[ $value =~ $REGEX ]] && value=${BASH_REMATCH[1]}
               found=false
               echo "value2 = $value"
               target="/copilot/${{ vars.COPILOT_APPLICATION }}/${{ vars.COPILOT_ENVIRONMENT }}/secrets/$value"

--- a/.github/workflows/secret-check.yml
+++ b/.github/workflows/secret-check.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Get secrets from Param Store in SSM
       id: ssmSecrets
       run: |
-        echo "ssmSecrets=($(aws ssm get-parameters-by-path --recursive --path /copilot/evidence-hub-dashboard/dev/secrets))" >> $GITHUB_OUTPUT
+        echo "ssmSecrets=$(aws ssm get-parameters-by-path --output json --recursive --path /copilot/evidence-hub-dashboard/dev/secrets | jq -c)" >> $GITHUB_OUTPUT
     - name: Compare secrets
       run: |
         #!/bin/bash

--- a/.github/workflows/secret-check.yml
+++ b/.github/workflows/secret-check.yml
@@ -36,14 +36,14 @@ jobs:
     - name: Get secrets from Param Store in SSM
       id: ssmSecrets
       run: |
-        echo "ssmSecrets=($(aws ssm get-parameters-by-path --recursive --path /copilot/evidence-hub-dashboard/dev/secrets | jq .Parameters[].Name))" >> $GITHUB_OUTPUT
+        echo "ssmSecrets=($(aws ssm get-parameters-by-path --recursive --path /copilot/evidence-hub-dashboard/dev/secrets))" >> $GITHUB_OUTPUT
     - name: Compare secrets
       run: |
         #!/bin/bash
 
         # Load the output of a CLI command into an array
         ssmSecrets=(${{ steps.ssmSecrets.outputs.ssmSecrets }})
-        manifestSecrets=(${{ steps.manifestSecrets.outputs.result }})
+        manifestSecrets=$(${{ steps.manifestSecrets.outputs.result }} | jq .Parameters[].Name )
 
         # Iterate over the array and print the values
         REGEX='([A-Za-z0-9_]+)'

--- a/.github/workflows/secret-check.yml
+++ b/.github/workflows/secret-check.yml
@@ -49,16 +49,17 @@ jobs:
         REGEX='([A-Za-z0-9_]+)'
         for value in "${manifestSecrets[@]}"
         do
-            echo "value = $value"
             if [ "$value" != "[" ] && [ "$value" != "]" && [ "$value" != "-"]; then
               # extract just regex match from value
               [[ $value =~ $REGEX ]] && value=${BASH_REMATCH[1]}
               found=false
               target="/copilot/${{ vars.COPILOT_APPLICATION }}/${{ vars.COPILOT_ENVIRONMENT }}/secrets/$value"
+              echo "value = $value"
               echo "target = $target"
               for ((idx=0; idx<${#ssmSecrets[@]}; ++idx)); do
+                echo "ssmSecrets[$idx] = ${ssmSecrets[$idx]}"
                 if grep -q "$value" <<< "${ssmSecrets[$idx]}"; then
-                  echo "found";
+                  echo "found $value";
                   found=true;
                 fi
               done

--- a/.github/workflows/secret-check.yml
+++ b/.github/workflows/secret-check.yml
@@ -43,7 +43,7 @@ jobs:
 
         # Load the output of a CLI command into an array
         ssmString=${{ steps.ssmSecrets.outputs.ssmSecrets }}
-        manifestString="${{ steps.manifestSecrets.outputs.result }}"
+        manifestString=[${{ steps.manifestSecrets.outputs.result }}]
         IFS=',' read -r -a ssmSecrets <<< "$ssmString"
         IFS='\n-' read -r -a manifestSecrets <<< "$manifestString"
 

--- a/.github/workflows/secret-check.yml
+++ b/.github/workflows/secret-check.yml
@@ -58,8 +58,8 @@ jobs:
         manifestString=${{ steps.manifestSecrets.outputs.result }}
         IFS=',' read -r -a ssmSecrets <<< "$ssmString"
         IFS=',' read -r -a manifestSecrets <<< "$manifestString"
-        echo "ssmSecrets = '${ssmSecrets[*]}'"
-        echo "manSecrets = '${manifestSecrets[*]}'"
+        #echo "ssmSecrets = '${ssmSecrets[*]}'"
+        #echo "manSecrets = '${manifestSecrets[*]}'"
 
         # Iterate over the array and print the values
         REGEX='([A-Za-z0-9_]+)'

--- a/.github/workflows/secret-check.yml
+++ b/.github/workflows/secret-check.yml
@@ -51,7 +51,7 @@ jobs:
         for value in "${manifestSecrets[@]}"
         do
             echo "value1 = $value"
-            if [ "$value" != "[" ] && [ "$value" != "]" && [ "$value" != "-"]; then
+            if [ $value =~ $REGEX ]; then
               # extract just regex match from value
               [[ $value =~ $REGEX ]] && value=${BASH_REMATCH[1]}
               found=false

--- a/.github/workflows/secret-check.yml
+++ b/.github/workflows/secret-check.yml
@@ -23,23 +23,10 @@ jobs:
     - name: Checkout repo
       uses: actions/checkout@v4
     - name: Get secrets from manifest.yml
-      uses: mikefarah/yq@master
-      with:
-        cmd: yq -h
-    - name: Get secrets from manifest.yml
-      uses: mikefarah/yq@master
-      with:
-        cmd: yq --output-format shell '.secrets | keys' copilot/${{ vars.COPILOT_SERVICE }}/manifest.yml
-    - name: Get secrets from manifest.yml
-      uses: mikefarah/yq@master
-      with:
-        cmd: yq --output-format csv '.secrets | keys' copilot/${{ vars.COPILOT_SERVICE }}/manifest.yml
-    - name: Get secrets from manifest.yml
       id: manifestSecrets
       uses: mikefarah/yq@master
       with:
-        cmd: yq -P --output-format json '.secrets | keys' copilot/${{ vars.COPILOT_SERVICE }}/manifest.yml
-    
+        cmd: yq -oj '.secrets | keys' copilot/${{ vars.COPILOT_SERVICE }}/manifest.yml
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
@@ -57,45 +44,21 @@ jobs:
       uses: jannekem/run-python-script-action@v1
       with:
         script: |
-          print(${{ steps.ssmSecrets.outputs.ssmSecrets }})
-          print(${{ steps.manifestSecrets.outputs.result }})
-    
-    - name: Compare secrets
-      run: |
-        #!/bin/bash
+          ssmSecrets = ${{ steps.ssmSecrets.outputs.ssmSecrets }}
+          manifestSecrets = ${{ steps.manifestSecrets.outputs.result }}
+          manifestSet = set(manifestSecrets)
+          ssmSet = set()
 
-        # Load the output of a CLI command into an array
-        ssmString=${{ steps.ssmSecrets.outputs.ssmSecrets }}
-        manifestString=${{ steps.manifestSecrets.outputs.result }}
-        IFS=',' read -r -a ssmSecrets <<< "$ssmString"
-        IFS=',' read -r -a manifestSecrets <<< "$manifestString"
-        # echo "ssmSecrets = '${ssmSecrets[*]}'"
-        # echo "manSecrets = '${manifestSecrets[*]}'"
+          # strip prefix from ssmSecrets and the Sets should be identical
+          for s in ssmSecrets:
+            ssmSet.add(s.split("/")[-1])
 
-        # Iterate over the array and print the values
-        REGEX='([A-Za-z0-9_]+)'
-        for value in "${manifestSecrets[@]}"
-        do
-            echo "value1=$value."
-            if [[ $value =~ $REGEX ]]; then
-              # extract just regex match from value
-              #[[ $value =~ $REGEX ]] && value=${BASH_REMATCH[1]}
-              value=`echo $value | sed 's/ *$//g'`
-              found=false
-              echo "value2=$value."
-              target="/copilot/${{ vars.COPILOT_APPLICATION }}/${{ vars.COPILOT_ENVIRONMENT }}/secrets/$value"
-              echo "target=$target."
-              for ((idx=0; idx<${#ssmSecrets[@]}; ++idx)); do
-                echo "ssmSecrets[$idx]=${ssmSecrets[$idx]}."
-                if grep -q "$value" <<< "${ssmSecrets[$idx]}"; then
-                  echo "found $value.";
-                  found=true;
-                fi
-              done
-              if [ $found == false ]; then
-                echo "NOT FOUND $value.";
-                exit 1;
-              fi
-            fi
-        done
-        exit 0;
+          if manifestSet - ssmSet != set():
+            print("ERROR: Following secrets exist in manifest but not in SSM. Check the Param Store")
+            print(manifestSet - ssmSet)
+            exit(1)
+          if ssmSet - manifestSet != set():
+            print("ERROR: Following secrets exist in SSM but not in the manifest. Check the service manifest.yml")
+            print(ssmSet - manifestSet)
+            exit(1)
+          exit(0)

--- a/.github/workflows/secret-check.yml
+++ b/.github/workflows/secret-check.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Get secrets from Param Store in SSM
       id: ssmSecrets
       run: |
-        echo "ssmSecrets=$(aws ssm get-parameters-by-path --recursive --path copilot/evidence-hub-dashboard/dev/secrets | jq .Parameters[].Name)" >> $GITHUB_OUTPUT
+        echo "ssmSecrets=$(aws ssm get-parameters-by-path --recursive --path /copilot/evidence-hub-dashboard/dev/secrets | jq .Parameters[].Name)" >> $GITHUB_OUTPUT
     - name: Compare secrets
       run: |
         #!/bin/bash

--- a/.github/workflows/secret-check.yml
+++ b/.github/workflows/secret-check.yml
@@ -48,7 +48,18 @@ jobs:
     - name: Get secrets from Param Store in SSM
       id: ssmSecrets
       run: |
-        echo "ssmSecrets=$(aws ssm get-parameters-by-path --output json --recursive --path /copilot/${{ vars.COPILOT_APPLICATION }}/${{ vars.COPILOT_ENVIRONMENT }}/secrets | jq '.Parameters[].Name' | jq -s -c)" >> $GITHUB_OUTPUT
+        echo "ssmSecrets=$(aws ssm get-parameters-by-path --output json --recursive --path /copilot/${{ vars.COPILOT_APPLICATION }}/${{ vars.COPILOT_ENVIRONMENT }}/secrets | jq '.Parameters[].Name' | jq -s -c)" >> $GITHUB_OUTPUT  
+    - name: Setup Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.x'
+    - name: Compare Secrets Python
+      uses: jannekem/run-python-script-action@v1
+      with:
+        script: |
+          print(${{ steps.ssmSecrets.outputs.ssmSecrets }})
+          print(${{ steps.manifestSecrets.outputs.result }})
+    
     - name: Compare secrets
       run: |
         #!/bin/bash
@@ -58,8 +69,8 @@ jobs:
         manifestString=${{ steps.manifestSecrets.outputs.result }}
         IFS=',' read -r -a ssmSecrets <<< "$ssmString"
         IFS=',' read -r -a manifestSecrets <<< "$manifestString"
-        #echo "ssmSecrets = '${ssmSecrets[*]}'"
-        #echo "manSecrets = '${manifestSecrets[*]}'"
+        # echo "ssmSecrets = '${ssmSecrets[*]}'"
+        # echo "manSecrets = '${manifestSecrets[*]}'"
 
         # Iterate over the array and print the values
         REGEX='([A-Za-z0-9_]+)'

--- a/.github/workflows/secret-check.yml
+++ b/.github/workflows/secret-check.yml
@@ -36,8 +36,7 @@ jobs:
     - name: Get secrets from Param Store in SSM
       id: ssmSecrets
       run: |
-        echo "ssmSecrets=$(aws ssm get-parameters-by-path --recursive --path /copilot/evidence-hub-dashboard/dev/secrets | jq .Parameters[].Name)" >> $GITHUB_OUTPUT
-    
+        echo "ssmSecrets=$(aws ssm get-parameters-by-path --recursive --path copilot/evidence-hub-dashboard/dev/secrets | jq .Parameters[].Name)" >> $GITHUB_OUTPUT
     - name: Compare secrets
       run: |
         #!/bin/bash

--- a/.github/workflows/secret-check.yml
+++ b/.github/workflows/secret-check.yml
@@ -26,7 +26,7 @@ jobs:
       id: manifestSecrets
       uses: mikefarah/yq@master
       with:
-        cmd: yq '.secrets | keys' copilot/${{ vars.COPILOT_SERVICE }}/manifest.yml
+        cmd: yq '.secrets | keys' copilot/${{ vars.COPILOT_SERVICE }}/manifest.yml | yq -c
     
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/secret-check.yml
+++ b/.github/workflows/secret-check.yml
@@ -52,13 +52,11 @@ jobs:
           # strip prefix from ssmSecrets and the Sets should be identical
           for s in ssmSecrets:
             ssmSet.add(s.split("/")[-1])
-
+          if ssmSet - manifestSet != set():
+            print("WARNING: Following secrets exist in SSM but not in the manifest.")
+            print(ssmSet - manifestSet)
           if manifestSet - ssmSet != set():
             print("ERROR: Following secrets exist in manifest but not in SSM. Check the Param Store")
             print(manifestSet - ssmSet)
-            exit(1)
-          if ssmSet - manifestSet != set():
-            print("ERROR: Following secrets exist in SSM but not in the manifest. Check the service manifest.yml")
-            print(ssmSet - manifestSet)
             exit(1)
           exit(0)

--- a/.github/workflows/secret-check.yml
+++ b/.github/workflows/secret-check.yml
@@ -51,7 +51,7 @@ jobs:
         for value in "${manifestSecrets[@]}"
         do
             echo "value1 = $value"
-            if [ $value =~ $REGEX ]; then
+            if [[ $value =~ $REGEX ]]; then
               # extract just regex match from value
               #[[ $value =~ $REGEX ]] && value=${BASH_REMATCH[1]}
               value="echo $value | sed 's/ *$//g'"

--- a/.github/workflows/secret-check.yml
+++ b/.github/workflows/secret-check.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Get secrets from Param Store in SSM
       id: ssmSecrets
       run: |
-        echo "ssmSecrets=$(aws ssm get-parameters-by-path --recursive --path /copilot/evidence-hub-dashboard/dev/secrets | jq .Parameters[].Name)" >> $GITHUB_OUTPUT
+        echo "ssmSecrets=($(aws ssm get-parameters-by-path --recursive --path /copilot/evidence-hub-dashboard/dev/secrets | jq .Parameters[].Name))" >> $GITHUB_OUTPUT
     - name: Compare secrets
       run: |
         #!/bin/bash

--- a/.github/workflows/secret-check.yml
+++ b/.github/workflows/secret-check.yml
@@ -23,6 +23,10 @@ jobs:
     - name: Checkout repo
       uses: actions/checkout@v4
     - name: Get secrets from manifest.yml
+      uses: mikefarah/yq@master
+      with:
+        cmd: yq -h
+    - name: Get secrets from manifest.yml
       id: manifestSecrets
       uses: mikefarah/yq@master
       with:

--- a/.github/workflows/secret-check.yml
+++ b/.github/workflows/secret-check.yml
@@ -43,7 +43,8 @@ jobs:
 
         # Load the output of a CLI command into an array
         ssmSecrets=${{ steps.ssmSecrets.outputs.ssmSecrets }}
-        manifestSecrets="${{ steps.manifestSecrets.outputs.result }}"
+        manifestString="${{ steps.manifestSecrets.outputs.result }}"
+        IFS = '\n-' read -r -a manifestSecrets <<< "$manifestString"
 
         # Iterate over the array and print the values
         REGEX='([A-Za-z0-9_]+)'

--- a/.github/workflows/secret-check.yml
+++ b/.github/workflows/secret-check.yml
@@ -26,7 +26,7 @@ jobs:
       id: manifestSecrets
       uses: mikefarah/yq@master
       with:
-        cmd: yq '.secrets | keys' copilot/evidence-hub/manifest.yml
+        cmd: yq '.secrets | keys' copilot/${{ vars.COPILOT_SERVICE }}/manifest.yml
     
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4
@@ -36,7 +36,7 @@ jobs:
     - name: Get secrets from Param Store in SSM
       id: ssmSecrets
       run: |
-        echo "ssmSecrets=$(aws ssm get-parameters-by-path --output json --recursive --path /copilot/evidence-hub-dashboard/dev/secrets | jq -c)" >> $GITHUB_OUTPUT
+        echo "ssmSecrets=$(aws ssm get-parameters-by-path --output json --recursive --path /copilot/${{ vars.COPILOT_APPLICATION }}/${{ vars.COPILOT_ENVIRONMENT }}/secrets | jq -c)" >> $GITHUB_OUTPUT
     - name: Compare secrets
       run: |
         #!/bin/bash
@@ -49,11 +49,11 @@ jobs:
         REGEX='([A-Za-z0-9_]+)'
         for value in "${manifestSecrets[@]}"
         do
-            if [ "$value" != "[" ] && [ "$value" != "]" ]; then
+            if [ "$value" != "[" ] && [ "$value" != "]" && [ "$value" != "-"]; then
               # extract just regex match from value
               [[ $value =~ $REGEX ]] && value=${BASH_REMATCH[1]}
               found=false
-              target="/copilot/evidence-hub-dashboard/dev/secrets/$value"
+              target="/copilot/${{ vars.COPILOT_APPLICATION }}/${{ vars.COPILOT_ENVIRONMENT }}/secrets/$value"
               for ((idx=0; idx<${#ssmSecrets[@]}; ++idx)); do
                 if grep -q "$value" <<< "${ssmSecrets[$idx]}"; then
                   found=true;

--- a/.github/workflows/secret-check.yml
+++ b/.github/workflows/secret-check.yml
@@ -25,11 +25,15 @@ jobs:
     - name: Get secrets from manifest.yml
       uses: mikefarah/yq@master
       with:
-        cmd: yq -h
+        cmd: yq -o t '.secrets | keys' copilot/${{ vars.COPILOT_SERVICE }}/manifest.yml
     - name: Get secrets from manifest.yml
       uses: mikefarah/yq@master
       with:
-        cmd: yq -V
+        cmd: yq -o c '.secrets | keys' copilot/${{ vars.COPILOT_SERVICE }}/manifest.yml
+    - name: Get secrets from manifest.yml
+      uses: mikefarah/yq@master
+      with:
+        cmd: yq -o j '.secrets | keys' copilot/${{ vars.COPILOT_SERVICE }}/manifest.yml
     - name: Get secrets from manifest.yml
       id: manifestSecrets
       uses: mikefarah/yq@master

--- a/.github/workflows/secret-check.yml
+++ b/.github/workflows/secret-check.yml
@@ -23,22 +23,10 @@ jobs:
     - name: Checkout repo
       uses: actions/checkout@v4
     - name: Get secrets from manifest.yml
-      uses: mikefarah/yq@master
-      with:
-        cmd: yq -o t '.secrets | keys' copilot/${{ vars.COPILOT_SERVICE }}/manifest.yml
-    - name: Get secrets from manifest.yml
-      uses: mikefarah/yq@master
-      with:
-        cmd: yq -o c '.secrets | keys' copilot/${{ vars.COPILOT_SERVICE }}/manifest.yml
-    - name: Get secrets from manifest.yml
-      uses: mikefarah/yq@master
-      with:
-        cmd: yq -o j '.secrets | keys' copilot/${{ vars.COPILOT_SERVICE }}/manifest.yml
-    - name: Get secrets from manifest.yml
       id: manifestSecrets
       uses: mikefarah/yq@master
       with:
-        cmd: yq '.secrets | keys' copilot/${{ vars.COPILOT_SERVICE }}/manifest.yml
+        cmd: yq -o j '.secrets | keys' copilot/${{ vars.COPILOT_SERVICE }}/manifest.yml
     
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/secret-check.yml
+++ b/.github/workflows/secret-check.yml
@@ -45,30 +45,30 @@ jobs:
         ssmString=${{ steps.ssmSecrets.outputs.ssmSecrets }}
         manifestString="${{ steps.manifestSecrets.outputs.result }}"
         IFS='\n-' read -r -a ssmSecrets <<< "$ssmString"
-        IFS='\n-' read -r -a manifestSecrets <<< "$manifestString"
+        IFS=',' read -r -a manifestSecrets <<< "$manifestString"
 
         # Iterate over the array and print the values
         REGEX='([A-Za-z0-9_]+)'
         for value in "${manifestSecrets[@]}"
         do
-            echo "value1 = $value"
+            echo "value1=$value."
             if [[ $value =~ $REGEX ]]; then
               # extract just regex match from value
               #[[ $value =~ $REGEX ]] && value=${BASH_REMATCH[1]}
               value=`echo $value | sed 's/ *$//g'`
               found=false
-              echo "value2 = $value"
+              echo "value2=$value."
               target="/copilot/${{ vars.COPILOT_APPLICATION }}/${{ vars.COPILOT_ENVIRONMENT }}/secrets/$value"
-              echo "target = $target"
+              echo "target=$target."
               for ((idx=0; idx<${#ssmSecrets[@]}; ++idx)); do
-                echo "ssmSecrets[$idx] = ${ssmSecrets[$idx]}"
+                echo "ssmSecrets[$idx]=${ssmSecrets[$idx]}."
                 if grep -q "$value" <<< "${ssmSecrets[$idx]}"; then
-                  echo "found $value";
+                  echo "found $value.";
                   found=true;
                 fi
               done
               if [ $found == false ]; then
-                echo "NOT FOUND $value";
+                echo "NOT FOUND $value.";
                 exit 1;
               fi
             fi

--- a/.github/workflows/secret-check.yml
+++ b/.github/workflows/secret-check.yml
@@ -43,7 +43,7 @@ jobs:
 
         # Load the output of a CLI command into an array
         ssmString=${{ steps.ssmSecrets.outputs.ssmSecrets }}
-        manifestString=[${{ steps.manifestSecrets.outputs.result }}]
+        manifestString=["${{ steps.manifestSecrets.outputs.result }}"]
         IFS=',' read -r -a ssmSecrets <<< "$ssmString"
         IFS='\n-' read -r -a manifestSecrets <<< "$manifestString"
 

--- a/.github/workflows/secret-check.yml
+++ b/.github/workflows/secret-check.yml
@@ -58,8 +58,8 @@ jobs:
         manifestString=${{ steps.manifestSecrets.outputs.result }}
         IFS=',' read -r -a ssmSecrets <<< "$ssmString"
         IFS=',' read -r -a manifestSecrets <<< "$manifestString"
-        echo "ssmSecrets = ${ssmSecrets[*]}"
-        echo "manSecrets = ${manifestSecrets[*]}"
+        echo "ssmSecrets = '${ssmSecrets[*]}'"
+        echo "manSecrets = '${manifestSecrets[*]}'"
 
         # Iterate over the array and print the values
         REGEX='([A-Za-z0-9_]+)'

--- a/.github/workflows/secret-check.yml
+++ b/.github/workflows/secret-check.yml
@@ -43,7 +43,7 @@ jobs:
 
         # Load the output of a CLI command into an array
         ssmString=${{ steps.ssmSecrets.outputs.ssmSecrets }}
-        manifestString=["${{ steps.manifestSecrets.outputs.result }}"]
+        manifestString=${{ steps.manifestSecrets.outputs.result }}
         IFS=',' read -r -a ssmSecrets <<< "$ssmString"
         IFS='\n-' read -r -a manifestSecrets <<< "$manifestString"
 

--- a/.github/workflows/secret-check.yml
+++ b/.github/workflows/secret-check.yml
@@ -44,8 +44,8 @@ jobs:
         # Load the output of a CLI command into an array
         ssmString=${{ steps.ssmSecrets.outputs.ssmSecrets }}
         manifestString="${{ steps.manifestSecrets.outputs.result }}"
-        IFS='\n-' read -r -a ssmSecrets <<< "$ssmString"
-        IFS=',' read -r -a manifestSecrets <<< "$manifestString"
+        IFS=',' read -r -a ssmSecrets <<< "$ssmString"
+        IFS='\n-' read -r -a manifestSecrets <<< "$manifestString"
 
         # Iterate over the array and print the values
         REGEX='([A-Za-z0-9_]+)'

--- a/.github/workflows/secret-check.yml
+++ b/.github/workflows/secret-check.yml
@@ -23,10 +23,18 @@ jobs:
     - name: Checkout repo
       uses: actions/checkout@v4
     - name: Get secrets from manifest.yml
+      uses: mikefarah/yq@master
+      with:
+        cmd: yq -h
+    - name: Get secrets from manifest.yml
+      uses: mikefarah/yq@master
+      with:
+        cmd: yq -V
+    - name: Get secrets from manifest.yml
       id: manifestSecrets
       uses: mikefarah/yq@master
       with:
-        cmd: yq -c '.secrets | keys' copilot/${{ vars.COPILOT_SERVICE }}/manifest.yml
+        cmd: yq '.secrets | keys' copilot/${{ vars.COPILOT_SERVICE }}/manifest.yml
     
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/secret-check.yml
+++ b/.github/workflows/secret-check.yml
@@ -43,7 +43,7 @@ jobs:
 
         # Load the output of a CLI command into an array
         ssmSecrets=${{ steps.ssmSecrets.outputs.ssmSecrets }}
-        manifestSecrets=[${{ steps.manifestSecrets.outputs.result }}]
+        manifestSecrets="${{ steps.manifestSecrets.outputs.result }}"
 
         # Iterate over the array and print the values
         REGEX='([A-Za-z0-9_]+)'

--- a/.github/workflows/secret-check.yml
+++ b/.github/workflows/secret-check.yml
@@ -27,10 +27,18 @@ jobs:
       with:
         cmd: yq -h
     - name: Get secrets from manifest.yml
+      uses: mikefarah/yq@master
+      with:
+        cmd: yq --output-format shell '.secrets | keys' copilot/${{ vars.COPILOT_SERVICE }}/manifest.yml
+    - name: Get secrets from manifest.yml
+      uses: mikefarah/yq@master
+      with:
+        cmd: yq --output-format csv '.secrets | keys' copilot/${{ vars.COPILOT_SERVICE }}/manifest.yml
+    - name: Get secrets from manifest.yml
       id: manifestSecrets
       uses: mikefarah/yq@master
       with:
-        cmd: yq -o j '.secrets | keys' copilot/${{ vars.COPILOT_SERVICE }}/manifest.yml
+        cmd: yq -P --output-format json '.secrets | keys' copilot/${{ vars.COPILOT_SERVICE }}/manifest.yml
     
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/secret-check.yml
+++ b/.github/workflows/secret-check.yml
@@ -54,6 +54,7 @@ jobs:
             if [ $value =~ $REGEX ]; then
               # extract just regex match from value
               #[[ $value =~ $REGEX ]] && value=${BASH_REMATCH[1]}
+              value="echo $value | sed 's/ *$//g'"
               found=false
               echo "value2 = $value"
               target="/copilot/${{ vars.COPILOT_APPLICATION }}/${{ vars.COPILOT_ENVIRONMENT }}/secrets/$value"

--- a/.github/workflows/secret-check.yml
+++ b/.github/workflows/secret-check.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Get secrets from Param Store in SSM
       id: ssmSecrets
       run: |
-        echo "ssmSecrets=$(aws ssm get-parameters-by-path --output json --recursive --path /copilot/${{ vars.COPILOT_APPLICATION }}/${{ vars.COPILOT_ENVIRONMENT }}/secrets | jq '.Parameters[].Name') | jq -s -c" >> $GITHUB_OUTPUT
+        echo "ssmSecrets=$(aws ssm get-parameters-by-path --output json --recursive --path /copilot/${{ vars.COPILOT_APPLICATION }}/${{ vars.COPILOT_ENVIRONMENT }}/secrets | jq '.Parameters[].Name' | jq -s -c)" >> $GITHUB_OUTPUT
     - name: Compare secrets
       run: |
         #!/bin/bash

--- a/.github/workflows/secret-check.yml
+++ b/.github/workflows/secret-check.yml
@@ -36,26 +36,29 @@ jobs:
     - name: Get secrets from Param Store in SSM
       id: ssmSecrets
       run: |
-        echo "ssmSecrets=$(aws ssm get-parameters-by-path --output json --recursive --path /copilot/${{ vars.COPILOT_APPLICATION }}/${{ vars.COPILOT_ENVIRONMENT }}/secrets | jq -c)" >> $GITHUB_OUTPUT
+        echo "ssmSecrets=$(aws ssm get-parameters-by-path --output json --recursive --path /copilot/${{ vars.COPILOT_APPLICATION }}/${{ vars.COPILOT_ENVIRONMENT }}/secrets | jq '.Parameters[].Name')" >> $GITHUB_OUTPUT
     - name: Compare secrets
       run: |
         #!/bin/bash
 
         # Load the output of a CLI command into an array
-        ssmSecrets=$(${{ steps.ssmSecrets.outputs.ssmSecrets }} | jq '.Parameters[].Name')
-        manifestSecrets=(${{ steps.manifestSecrets.outputs.result }})
+        ssmSecrets=${{ steps.ssmSecrets.outputs.ssmSecrets }}
+        manifestSecrets=${{ steps.manifestSecrets.outputs.result }}
 
         # Iterate over the array and print the values
         REGEX='([A-Za-z0-9_]+)'
         for value in "${manifestSecrets[@]}"
         do
+            echo "value = $value"
             if [ "$value" != "[" ] && [ "$value" != "]" && [ "$value" != "-"]; then
               # extract just regex match from value
               [[ $value =~ $REGEX ]] && value=${BASH_REMATCH[1]}
               found=false
               target="/copilot/${{ vars.COPILOT_APPLICATION }}/${{ vars.COPILOT_ENVIRONMENT }}/secrets/$value"
+              echo "target = $target"
               for ((idx=0; idx<${#ssmSecrets[@]}; ++idx)); do
                 if grep -q "$value" <<< "${ssmSecrets[$idx]}"; then
+                  echo "found";
                   found=true;
                 fi
               done

--- a/.github/workflows/secret-check.yml
+++ b/.github/workflows/secret-check.yml
@@ -50,12 +50,13 @@ jobs:
         REGEX='([A-Za-z0-9_]+)'
         for value in "${manifestSecrets[@]}"
         do
+            echo "value1 = $value"
             if [ "$value" != "[" ] && [ "$value" != "]" && [ "$value" != "-"]; then
               # extract just regex match from value
               [[ $value =~ $REGEX ]] && value=${BASH_REMATCH[1]}
               found=false
+              echo "value2 = $value"
               target="/copilot/${{ vars.COPILOT_APPLICATION }}/${{ vars.COPILOT_ENVIRONMENT }}/secrets/$value"
-              echo "value = $value"
               echo "target = $target"
               for ((idx=0; idx<${#ssmSecrets[@]}; ++idx)); do
                 echo "ssmSecrets[$idx] = ${ssmSecrets[$idx]}"

--- a/.github/workflows/secret-check.yml
+++ b/.github/workflows/secret-check.yml
@@ -42,8 +42,9 @@ jobs:
         #!/bin/bash
 
         # Load the output of a CLI command into an array
-        ssmSecrets=${{ steps.ssmSecrets.outputs.ssmSecrets }}
+        ssmString=${{ steps.ssmSecrets.outputs.ssmSecrets }}
         manifestString="${{ steps.manifestSecrets.outputs.result }}"
+        IFS='\n-' read -r -a ssmSecrets <<< "$ssmString"
         IFS='\n-' read -r -a manifestSecrets <<< "$manifestString"
 
         # Iterate over the array and print the values
@@ -54,7 +55,7 @@ jobs:
             if [[ $value =~ $REGEX ]]; then
               # extract just regex match from value
               #[[ $value =~ $REGEX ]] && value=${BASH_REMATCH[1]}
-              value="echo $value | sed 's/ *$//g'"
+              value=`echo $value | sed 's/ *$//g'`
               found=false
               echo "value2 = $value"
               target="/copilot/${{ vars.COPILOT_APPLICATION }}/${{ vars.COPILOT_ENVIRONMENT }}/secrets/$value"


### PR DESCRIPTION
This new workflow grabs the set secrets from the service manifest and compares them to the set of secrets stored in AWS Systems Manager Parameter Store. This will be used in CI builds before we build the image