### PR TITLE
Update buildx and login actions to remove node16 usage

### DIFF
--- a/.github/workflows/docker-build-push-scan-aws.yml
+++ b/.github/workflows/docker-build-push-scan-aws.yml
@@ -45,9 +45,9 @@ jobs:
     - name: downcase REPO
       run: echo "REPO=${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
     - name: Login to GitHub Container Registry
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}

--- a/.github/workflows/docker-build-push-scan-aws.yml
+++ b/.github/workflows/docker-build-push-scan-aws.yml
@@ -53,7 +53,7 @@ jobs:
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v1-node16
+      uses: aws-actions/configure-aws-credentials
       with:
         aws-region: ${{ vars.AWS_REGION }}
         role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}

--- a/.github/workflows/docker-build-push-scan-aws.yml
+++ b/.github/workflows/docker-build-push-scan-aws.yml
@@ -53,7 +53,7 @@ jobs:
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         aws-region: ${{ vars.AWS_REGION }}
         role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}

--- a/.github/workflows/docker-build-push-scan.yml
+++ b/.github/workflows/docker-build-push-scan.yml
@@ -32,9 +32,9 @@ jobs:
     - name: downcase REPO
       run: echo "REPO=${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
     - name: Login to GitHub Container Registry
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}

--- a/.github/workflows/ghcr-ecr-republish.yml
+++ b/.github/workflows/ghcr-ecr-republish.yml
@@ -35,9 +35,9 @@ jobs:
     - name: downcase REPO
       run: echo "REPO=${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
     - name: Login to GitHub Container Registry
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
@@ -48,7 +48,7 @@ jobs:
         aws-region: ${{ vars.AWS_REGION }}
         role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
     - name: Login to ECR
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         registry: ${{ vars.AWS_REGISTRY }}
     - name: Pull prior built named image from GHCR

--- a/.github/workflows/ghcr-ecr-republish.yml
+++ b/.github/workflows/ghcr-ecr-republish.yml
@@ -43,7 +43,7 @@ jobs:
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         aws-region: ${{ vars.AWS_REGION }}
         role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}

--- a/.github/workflows/ghcr-ecr-republish.yml
+++ b/.github/workflows/ghcr-ecr-republish.yml
@@ -43,7 +43,7 @@ jobs:
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v1-node16
+      uses: aws-actions/configure-aws-credentials
       with:
         aws-region: ${{ vars.AWS_REGION }}
         role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}

--- a/.github/workflows/secret-check.yml
+++ b/.github/workflows/secret-check.yml
@@ -37,7 +37,7 @@ jobs:
       run: |
         echo "ssmSecrets=$(aws ssm get-parameters-by-path --output json --recursive --path /copilot/${{ vars.COPILOT_APPLICATION }}/${{ vars.COPILOT_ENVIRONMENT }}/secrets | jq '.Parameters[].Name' | jq -s -c)" >> $GITHUB_OUTPUT  
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - name: Compare Secrets Python


### PR DESCRIPTION
Updating job versions to use latest with non-deprecated node version
Tested in https://github.com/graticule-life/study-portal/pull/258 and https://github.com/graticule-life/study-emr/pull/179

No node version warnings show in the action now!