### PR TITLE
Disable republish job for Dependabot

### DIFF
--- a/.github/workflows/ghcr-ecr-republish.yml
+++ b/.github/workflows/ghcr-ecr-republish.yml
@@ -26,6 +26,7 @@ env:
 
 jobs:
   republish:
+    if: (github.actor != 'dependabot[bot]')
     environment: ${{ inputs.environment }}
     permissions:
       id-token: write   # This is required for requesting the OIDC JWT


### PR DESCRIPTION
Got a dependabot PR to pass dev-ci-cd by adding an AWS_ROLE_TO_ASSUME Secret in Repo Settings -> Secrets & Variables -> Dependabot: e.g. https://github.com/graticule-life/study-portal/actions/runs/8885467122

This PR will disable the second part of this job for Dependabot built PRs. We do want to run through CI but not CD. This change will propagate to all our repos that use this workflow and Dependabot together