### PR TITLE
Add pytest workflow

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -8,6 +8,10 @@ on:
         required: false
         default: ''
         type: string
+      python_version:
+        description: 'Python version for installation and testing'
+        required: true
+        type: string
       pytest_args:
         description: 'Additional arguments for pytest. Ex. pytest <dir/tests>'
         required: false
@@ -18,22 +22,21 @@ jobs:
   pytest:
     name: "Launch tests with pytest"
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.11", "3.12"]
+    # strategy:
+    #   matrix:
+    #     python-version: ["3.11", "3.12"]
   
     steps:
       - uses: actions/checkout@v4
 
-      - name: "Set up Python ${{ matrix.python-version }}"
+      - name: "Set up Python ${{ inputs.python_version }}"
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ inputs.python_version }}
 
       - name: Run command
         if: ${{ inputs.cmd != '' }}
         run: ${{ inputs.cmd }}
-        shell: bash
 
       - name: Install dependencies
         run: |
@@ -46,4 +49,3 @@ jobs:
         run: |
           source venv/bin/activate
           pytest ${{ inputs.pytest_args }}
-        shell: bash

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -22,9 +22,6 @@ jobs:
   pytest:
     name: "Launch tests with pytest"
     runs-on: ubuntu-latest
-    # strategy:
-    #   matrix:
-    #     python-version: ["3.11", "3.12"]
   
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         python-version: ["3.11", "3.12"]
     env:
-      COPILOT_ENVIRONMENT_NAME: ${{ github.event.inputs.environment }}
+      COPILOT_ENVIRONMENT_NAME: ${{ inputs.environment }}
   
     steps:
       - uses: actions/checkout@v4
@@ -42,5 +42,5 @@ jobs:
       - name: Run Pytest
         run: |
           source venv/bin/activate
-          pytest ${{ github.event.inputs.pytest_args }}
+          pytest ${{ inputs.pytest_args }}
         shell: bash

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,9 +1,7 @@
 name: Pytest
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
-  workflow_dispatch:
+  workflow_call:
     inputs:
       environment:
         description: 'Copilot environment name'

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -7,10 +7,12 @@ on:
         description: 'Copilot environment name'
         required: false
         default: ''
+        type: string
       pytest_args:
         description: 'Additional arguments for pytest. Ex. pytest <dir/tests>'
         required: false
-        default: 'test/'
+        default: ''
+        type: string
 
 jobs:
   pytest:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,46 @@
+name: Pytest
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Copilot environment name'
+        required: false
+        default: ''
+      pytest_args:
+        description: 'Additional arguments for pytest. Ex. pytest <dir/tests>'
+        required: false
+        default: 'test/'
+
+jobs:
+  pytest:
+    name: "Launch tests with pytest"
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
+    env:
+      COPILOT_ENVIRONMENT_NAME: ${{ github.event.inputs.environment }}
+  
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: "Set up Python ${{ matrix.python-version }}"
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m venv venv
+          source venv/bin/activate
+          pip install --upgrade pip
+          pip install -e .[dev]
+
+      - name: Run Pytest
+        run: |
+          source venv/bin/activate
+          pytest ${{ github.event.inputs.pytest_args }}
+        shell: bash

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -2,9 +2,8 @@ name: Pytest
 
 on:
   workflow_call:
-    inputs:
-      environment:
-        description: 'Copilot environment name'
+      cmd:
+        description: 'Command to run before pip install'
         required: false
         default: ''
         type: string
@@ -21,8 +20,6 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.11", "3.12"]
-    env:
-      COPILOT_ENVIRONMENT_NAME: ${{ inputs.environment }}
   
     steps:
       - uses: actions/checkout@v4
@@ -32,13 +29,18 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Run command
+        if: ${{ inputs.cmd != '' }}
+        run: ${{ inputs.cmd }}
+        shell: bash
+
       - name: Install dependencies
         run: |
           python -m venv venv
           source venv/bin/activate
           pip install --upgrade pip
           pip install -e .[dev]
-
+      
       - name: Run Pytest
         run: |
           source venv/bin/activate

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -2,6 +2,7 @@ name: Pytest
 
 on:
   workflow_call:
+    inputs:
       cmd:
         description: 'Command to run before pip install'
         required: false


### PR DESCRIPTION
This PR is adding a reusable pytest workflow.

For my case, I need to set the environment variable so I kept this general with an option to pass a command  (`cmd`) before pip install. I also added an optional `pytest_args` that could be to used to pass additional command-line arguments. For example, `pytest -v` would have `pytest_args: "-v"`

<br>

This ran successfully from a branch in global evidence hub: https://github.com/graticule-life/global-evidence-hub/actions/runs/9182109457